### PR TITLE
fullsky_geometry, made CarProjection abstract, broadcasting, tests

### DIFF
--- a/src/Pixell.jl
+++ b/src/Pixell.jl
@@ -6,7 +6,9 @@ using FFTW
 using Printf
 
 include("enmap.jl")
+include("enmap_ops.jl")
 
-export Enmap
+export Enmap, CarProjection
+export fullsky_geometry
 
 end

--- a/src/Pixell.jl
+++ b/src/Pixell.jl
@@ -8,7 +8,7 @@ using Printf
 include("enmap.jl")
 include("enmap_ops.jl")
 
-export Enmap, CarProjection
+export Enmap, CarClenshawCurtis
 export fullsky_geometry
 
 end

--- a/src/enmap.jl
+++ b/src/enmap.jl
@@ -88,7 +88,7 @@ struct NoWCS end
 combine(x::NoWCS, y) = y
 combine(x, y::NoWCS) = x
 combine(x::NoWCS, ::NoWCS) = x
-combine(x::Enmap, y::Enmap) = x  # TODO: check compatibility
+combine(x::WCSTransform, y::WCSTransform) = x  # TODO: check compatibility
 
 
 ####

--- a/src/enmap.jl
+++ b/src/enmap.jl
@@ -1,7 +1,7 @@
 using Base: ViewIndex, @propagate_inbounds, AbstractCartesianIndex
 
-abstract type MapProjection end
-abstract type EquiCylProjection <: MapProjection end  # equidistant cylindrical projection
+abstract type AbstractMapProjection end
+abstract type EquiCylProjection <: AbstractMapProjection end  # equidistant cylindrical projection
 
 struct CarProjection <: EquiCylProjection end  # plate carrée
 struct CeaProjection <: EquiCylProjection end  # cylindrical equal area
@@ -13,7 +13,7 @@ It only implements the subset of Base.Array operations which are common on maps.
 You should work with the data directly using `enmap_instance.data` if you need
 additional Array functions.
 """
-struct Enmap{T,N,AA<:AbstractArray,P<:MapProjection} <: AbstractArray{T,N}
+struct Enmap{T,N,AA<:AbstractArray,P<:AbstractMapProjection} <: AbstractArray{T,N}
     data::AA  # some kind of abstract array
     wcs::WCSTransform  # WCS object from WCS.jl
 end

--- a/src/enmap.jl
+++ b/src/enmap.jl
@@ -2,9 +2,10 @@ using Base: ViewIndex, @propagate_inbounds, AbstractCartesianIndex
 
 abstract type AbstractMapProjection end
 abstract type EquiCylProjection <: AbstractMapProjection end  # equidistant cylindrical projection
+abstract type CarProjection <: EquiCylProjection end          # plate carrée
 
-struct CarProjection <: EquiCylProjection end  # plate carrée
-struct CeaProjection <: EquiCylProjection end  # cylindrical equal area
+struct CarClenshawCurtis <: CarProjection end      # plate carrée with pixels on poles and equator
+
 
 """
 Map type, contains an AbstractArray and a WCS object, but behaves like the
@@ -22,9 +23,9 @@ end
 function Enmap(data::A, wcs, ::Type{PT}) where {A<:AbstractArray,PT}
     Enmap{eltype(A),ndims(A),A,PT}(data, wcs)
 end
-# create CAR maps by default
+# create CAR (Clenshaw-Curtis variant) maps by default
 function Enmap(data::A, wcs) where {A<:AbstractArray}
-    Enmap{eltype(A),ndims(A),A,CarProjection}(data, wcs)
+    Enmap{eltype(A),ndims(A),A,CarClenshawCurtis}(data, wcs)
 end
 
 Base.parent(x::Enmap) = x.data

--- a/src/enmap_ops.jl
+++ b/src/enmap_ops.jl
@@ -1,5 +1,5 @@
 
-function fullsky_geometry(proj::Type{<:CarProjection}, res; shape = nothing, dims = ())
+function fullsky_geometry(proj::Type{<:CarClenshawCurtis}, res; shape = nothing, dims = ())
     if isnothing(shape)
         shape = (round.(Int, (2π, π) ./ res .+ (0, 1)))  # CAR has pixels on poles
     end
@@ -20,8 +20,8 @@ function fullsky_geometry(proj::Type{<:CarProjection}, res; shape = nothing, dim
     return (nx, ny, dims...), wcs
 end
 
-fullsky_geometry(proj::Type{<:CarProjection}, res::Number; shape = nothing, dims = ()) =
+fullsky_geometry(proj::Type{<:CarClenshawCurtis}, res::Number; shape = nothing, dims = ()) =
     fullsky_geometry(proj, (res, res); shape = shape, dims = dims)
 
 fullsky_geometry(res; shape = nothing, dims = ()) =
-    fullsky_geometry(CarProjection, res; shape = shape, dims = dims)
+    fullsky_geometry(CarClenshawCurtis, res; shape = shape, dims = dims)

--- a/src/enmap_ops.jl
+++ b/src/enmap_ops.jl
@@ -1,0 +1,27 @@
+
+function fullsky_geometry(proj::Type{<:CarProjection}, res; shape = nothing, dims = ())
+    if isnothing(shape)
+        shape = (round.(Int, (2π, π) ./ res .+ (0, 1)))  # CAR has pixels on poles
+    end
+    nx, ny = shape
+    resx, resy = res
+
+    @assert abs(resx * nx - 2π) < 1e-8 "Horizontal resolution does not evenly divide the sky; this is required for SHTs."
+    @assert abs(resy * (ny - 1) - π) < 1e-8 "Vertical resolution does not evenly divide the sky; this is required for SHTs."
+
+    # Note the reference point is shifted by half a pixel to keep
+    # the grid in bounds, from ra=180+cdelt/2 to ra=-180+cdelt/2.
+    wcs = WCSTransform(2;
+        cdelt = [-360.0 / nx, 180.0 / (ny - 1)],
+        ctype = ["RA---CAR", "DEC--CAR"],
+        crpix = [floor(nx / 2) + 0.5, (ny + 1) / 2],
+        crval = [resy * 90 / π, 0])
+
+    return (nx, ny, dims...), wcs
+end
+
+fullsky_geometry(proj::Type{<:CarProjection}, res::Number; shape = nothing, dims = ()) =
+    fullsky_geometry(proj, (res, res); shape = shape, dims = dims)
+
+fullsky_geometry(res; shape = nothing, dims = ()) =
+    fullsky_geometry(CarProjection, res; shape = shape, dims = dims)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,3 +16,14 @@ using Test
     shape, wcs = fullsky_geometry(deg2rad(5); dims=(3,))
     @test shape == (72, 37, 3)
 end
+
+
+@testset "Enmap broadcasting" begin
+    shape, wcs = fullsky_geometry(deg2rad(1); dims=(3,))
+    A, B = rand(shape...), rand(shape...)
+    ma = Enmap(A, wcs)
+    mb = Enmap(B, wcs)
+    @test A .+ B == ma .+ mb
+    @test A .+ B == ma .+ B
+    @test A .+ B .* sin.(A.^2) == (ma .+ mb .* sin.(ma.^2))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,18 @@
 using Pixell
 using Test
 
-@testset "Pixell.jl" begin
-    # Write your tests here.
+
+@testset "Enmap geometry" begin
+    shape, wcs = fullsky_geometry(deg2rad(1 / 60))
+    @test wcs.cdelt ≈ [-0.016666666666666666, 0.016666666666666666]
+    @test wcs.crpix ≈ [10800.5, 5401.0]
+    @test wcs.crval ≈ [0.008333333333333333, 0.0]
+
+    shape, wcs = fullsky_geometry(deg2rad(1 / 61))
+    @test wcs.cdelt ≈ [-0.01639344262295082, 0.01639344262295082]
+    @test wcs.crpix ≈ [10980.5, 5491.0]
+    @test wcs.crval ≈ [0.00819672131147541, 0.0]
+
+    shape, wcs = fullsky_geometry(deg2rad(5); dims=(3,))
+    @test shape == (72, 37, 3)
 end


### PR DESCRIPTION
This PR adds `fullsky_geometry()`, with tests in `test/runtests.jl`. It also adds tests for broadcasting, and fixes a bug discovered by those tests.

This PR also makes `CarProjection` an abstract type. The functionality of that type has been replaced with the more specific subtype, `CarClenshawCurtis`. 