### PR TITLE
properly handle WCS when slicing Enmap

### DIFF
--- a/src/Pixell.jl
+++ b/src/Pixell.jl
@@ -8,7 +8,7 @@ using Printf
 include("enmap.jl")
 include("enmap_ops.jl")
 
-export Enmap, CarClenshawCurtis
+export Enmap, CarClenshawCurtis, getwcs
 export fullsky_geometry, slice_geometry
 export pix2sky, pix2sky!, sky2pix, sky2pix!
 export read_map, write_map

--- a/src/Pixell.jl
+++ b/src/Pixell.jl
@@ -9,7 +9,7 @@ include("enmap.jl")
 include("enmap_ops.jl")
 
 export Enmap, CarClenshawCurtis
-export fullsky_geometry
+export fullsky_geometry, slice_geometry
 export pix2sky, pix2sky!, sky2pix, sky2pix!
 export read_map, write_map
 

--- a/src/enmap.jl
+++ b/src/enmap.jl
@@ -50,7 +50,10 @@ Base.IndexStyle(x::Enmap) = IndexStyle(parent(x))
 @propagate_inbounds Base.view(A::Enmap, idxs...) = Enmap(view(parent(A), idxs...), getwcs(A))
 
 @propagate_inbounds Base.getindex(x::Enmap, i::Int...) = getindex(parent(x), i...)
-@propagate_inbounds Base.getindex(x::Enmap, i...) = enmapwrap(x, getindex(parent(x), i...))
+@propagate_inbounds function Base.getindex(x::Enmap, i...) 
+    print("SLICE\n")
+    enmapwrap(x, getindex(parent(x), i...))
+end
 @propagate_inbounds Base.setindex!(x::Enmap, v, i...) = (setindex!(parent(x), v, i...); x)
 
 function Base.similar(x::Enmap, ::Type{S}, dims::NTuple{<:Any,Int}) where {S}

--- a/src/enmap.jl
+++ b/src/enmap.jl
@@ -45,9 +45,18 @@ Base.size(x::Enmap) = size(parent(x))
 Base.axes(x::Enmap) = Base.axes(parent(x))
 Base.IndexStyle(x::Enmap) = IndexStyle(parent(x))
 
-@propagate_inbounds Base.view(A::Enmap, idxs::ViewIndex...) = Enmap(view(parent(A), idxs...), getwcs(A))
-@propagate_inbounds Base.view(A::Enmap, idxs::Union{ViewIndex,AbstractCartesianIndex}...) = Enmap(view(parent(A), idxs...), getwcs(A))
-@propagate_inbounds Base.view(A::Enmap, idxs...) = Enmap(view(parent(A), idxs...), getwcs(A))
+@propagate_inbounds function Base.view(x::Enmap, idxs::ViewIndex...) 
+    new_shape, new_wcs = slice_geometry(size(x), getwcs(x), idxs...)
+    Enmap(view(parent(x), idxs...), new_wcs)
+end
+@propagate_inbounds function Base.view(x::Enmap, idxs::Union{ViewIndex,AbstractCartesianIndex}...) 
+    new_shape, new_wcs = slice_geometry(size(x), getwcs(x), idxs...)
+    Enmap(view(parent(x), idxs...), new_wcs)
+end
+@propagate_inbounds function Base.view(x::Enmap, idxs...) 
+    new_shape, new_wcs = slice_geometry(size(x), getwcs(x), idxs...)
+    Enmap(view(parent(x), idxs...), new_wcs)
+end
 
 @propagate_inbounds Base.getindex(x::Enmap, i::Int...) = getindex(parent(x), i...)
 @propagate_inbounds function Base.getindex(x::Enmap, i...)

--- a/src/enmap.jl
+++ b/src/enmap.jl
@@ -79,6 +79,15 @@ function enmapwrap(x::Enmap{T,N,AA,P}, val::AAV, i...) where {T,N,AA,P,NV,AAV<:A
     new_shape, new_wcs = slice_geometry(x, i...)
     Enmap{T,NV,AAV,P}(val, new_wcs)
 end
+
+
+# disable reducing dimension along the first two axes. should do more testing on this
+throw_1d_error() = error("An Enmap needs two WCS axes, for now. If you want a row, use a range i.e. enmap[5:5, :]")
+enmapwrap(x::Enmap{T,N,AA,P}, val::AAV, i1::Int, i...) where {T,N,AA,P,NV,AAV<:AbstractArray{T,NV}} =
+    throw_1d_error()
+enmapwrap(x::Enmap{T,N,AA,P}, val::AAV, i1, i2::Int, i...) where {T,N,AA,P,NV,AAV<:AbstractArray{T,NV}} =
+    throw_1d_error()
+
 enmapwrap(x, val, i...) = error("Unexpected result type $(typeof(val)).")
 
 Base.strides(x::Enmap) = strides(parent(x))

--- a/src/enmap.jl
+++ b/src/enmap.jl
@@ -46,15 +46,15 @@ Base.axes(x::Enmap) = Base.axes(parent(x))
 Base.IndexStyle(x::Enmap) = IndexStyle(parent(x))
 
 @propagate_inbounds function Base.view(x::Enmap, idxs::ViewIndex...) 
-    new_shape, new_wcs = slice_geometry(size(x), getwcs(x), idxs...)
+    new_shape, new_wcs = slice_geometry(x, idxs...)
     Enmap(view(parent(x), idxs...), new_wcs)
 end
 @propagate_inbounds function Base.view(x::Enmap, idxs::Union{ViewIndex,AbstractCartesianIndex}...) 
-    new_shape, new_wcs = slice_geometry(size(x), getwcs(x), idxs...)
+    new_shape, new_wcs = slice_geometry(x, idxs...)
     Enmap(view(parent(x), idxs...), new_wcs)
 end
 @propagate_inbounds function Base.view(x::Enmap, idxs...) 
-    new_shape, new_wcs = slice_geometry(size(x), getwcs(x), idxs...)
+    new_shape, new_wcs = slice_geometry(x, idxs...)
     Enmap(view(parent(x), idxs...), new_wcs)
 end
 
@@ -68,18 +68,18 @@ function Base.similar(x::Enmap, ::Type{S}, dims::NTuple{<:Any,Int}) where {S}
     Enmap(similar(parent(x), S, dims), getwcs(x))
 end
 
-enmapwrap(x::Enmap{T}, val::T) where {T} = val
+enmapwrap(x::Enmap{T}, val::T, i...) where {T} = val
 function enmapwrap(x::Enmap{T,N,AA,P}, val::AbstractArray{T,N}, i...) where {T,N,AA,P} 
-    new_shape, new_wcs = slice_geometry(size(x), getwcs(x), i...)
+    new_shape, new_wcs = slice_geometry(x, i...)
     Enmap{T,N,AA,P}(val, new_wcs)
 end
 
 # if array slicing ends up changing dimension, follow the parent
 function enmapwrap(x::Enmap{T,N,AA,P}, val::AAV, i...) where {T,N,AA,P,NV,AAV<:AbstractArray{T,NV}}
-    new_shape, new_wcs = slice_geometry(size(x), getwcs(x), i...)
+    new_shape, new_wcs = slice_geometry(x, i...)
     Enmap{T,NV,AAV,P}(val, new_wcs)
 end
-enmapwrap(x, val) = error("Unexpected result type $(typeof(val)).")
+enmapwrap(x, val, i...) = error("Unexpected result type $(typeof(val)).")
 
 Base.strides(x::Enmap) = strides(parent(x))
 Base.stride(x::Enmap, i::Int) = stride(parent(x), i)

--- a/src/enmap_ops.jl
+++ b/src/enmap_ops.jl
@@ -332,3 +332,4 @@ function slice_geometry(shape_all::NTuple{N}, wcs, sel_all::Vararg) where N
     wcs′.crpix = collect(crpix′)
     return (shape..., other_dims...), wcs′
 end
+slice_geometry(m::Enmap, sel_all::Vararg) = slice_geometry(size(m), getwcs(m), sel_all...)

--- a/src/enmap_ops.jl
+++ b/src/enmap_ops.jl
@@ -314,3 +314,20 @@ function sky2pix(m::Enmap{T,N,AA,CarClenshawCurtis},
     @assert length(skycoords) == 2
     return collect(sky2pix(m, first(skycoords), last(skycoords)))
 end
+
+# does not implement "nowrap" like pixell
+function slice_geometry(shape_all::NTuple{N}, wcs, sel::Vararg) where N
+    other_dims = shape_all[3:end]
+
+    starts = map(s -> (step(s) > 0) ? first(s) - 1 : first(s), sel)  # handle backward ranges too
+    steps = step.(sel)
+    sel_sizes = last.(sel) .- first.(sel) .+ steps
+    crpix′ = (crpix(wcs) .- (starts .+ 0.5)) ./ steps .+ 0.5
+    cdelt′ = cdelt(wcs) .* steps
+    shape = (sel_sizes .- sign.(steps)) .÷ steps
+
+    wcs′ = deepcopy(wcs)
+    wcs′.cdelt = collect(cdelt′)
+    wcs′.crpix = collect(crpix′)
+    return (shape..., other_dims...), wcs′
+end

--- a/src/enmap_ops.jl
+++ b/src/enmap_ops.jl
@@ -316,15 +316,16 @@ function sky2pix(m::Enmap{T,N,AA,CarClenshawCurtis},
 end
 
 # does not implement "nowrap" like pixell
-function slice_geometry(shape_all::NTuple{N}, wcs, sel::Vararg) where N
+function slice_geometry(shape_all::NTuple{N}, wcs, sel_all::Vararg) where N
     other_dims = shape_all[3:end]
+    sel = sel_all[1:2]
 
     starts = map(s -> (step(s) > 0) ? first(s) - 1 : first(s), sel)  # handle backward ranges too
     steps = step.(sel)
     sel_sizes = last.(sel) .- first.(sel) .+ steps
     crpix′ = (crpix(wcs) .- (starts .+ 0.5)) ./ steps .+ 0.5
     cdelt′ = cdelt(wcs) .* steps
-    shape = (sel_sizes .- sign.(steps)) .÷ steps
+    shape = sel_sizes .÷ steps
 
     wcs′ = deepcopy(wcs)
     wcs′.cdelt = collect(cdelt′)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,25 +64,25 @@ end
 ## 
 @testset "slice_geometry" begin
     shape0, wcs0 = fullsky_geometry(deg2rad(1))
-    shape, wcs = Pixell.slice_geometry(shape0, wcs0, 1:4, 11:-1:2)
+    shape, wcs = slice_geometry(shape0, wcs0, 1:4, 11:-1:2)
     @test (3, 9) == shape
     @test [-1.0, -1.0] ≈ wcs.cdelt
     @test [180.5, -79.0] ≈ wcs.crpix
     @test [0.5, 0.0] ≈ wcs.crval
     
-    shape, wcs = Pixell.slice_geometry(shape0, wcs0, 2:shape0[1], 6:12)
+    shape, wcs = slice_geometry(shape0, wcs0, 2:shape0[1], 6:12)
     @test (358, 6) == shape
     @test [-1.0, 1.0] ≈ wcs.cdelt
     @test [179.5, 86.0] ≈ wcs.crpix
     @test [0.5, 0.0] ≈ wcs.crval
 
-    shape, wcs = Pixell.slice_geometry(shape0, wcs0, 2:2:shape0[1], 1:12)
+    shape, wcs = slice_geometry(shape0, wcs0, 2:2:shape0[1], 1:12)
     @test (179, 11) == shape
     @test [-2.0, 1.0] ≈ wcs.cdelt
     @test [90.0, 91.0] ≈ wcs.crpix
     @test [0.5, 0.0] ≈ wcs.crval
 
-    shape, wcs = Pixell.slice_geometry(shape0, wcs0, 23:-4:3, 1:3:31)
+    shape, wcs = slice_geometry(shape0, wcs0, 23:-4:3, 1:3:31)
     @test (5, 10) == shape
     @test [4.0, 3.0] ≈ wcs.cdelt
     @test [-38.75, 30.666666666666668] ≈ wcs.crpix

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,6 +61,34 @@ end
     @test all(Pixell.cdelt(wcs) .== wcs.cdelt)
 end
 
+## 
+@testset "slice_geometry" begin
+    shape0, wcs0 = fullsky_geometry(deg2rad(1))
+    shape, wcs = Pixell.slice_geometry(shape0, wcs0, 1:4, 11:-1:2)
+    @test (3, 9) == shape
+    @test [-1.0, -1.0] ≈ wcs.cdelt
+    @test [180.5, -79.0] ≈ wcs.crpix
+    @test [0.5, 0.0] ≈ wcs.crval
+    
+    shape, wcs = Pixell.slice_geometry(shape0, wcs0, 2:shape0[1], 6:12)
+    @test (358, 6) == shape
+    @test [-1.0, 1.0] ≈ wcs.cdelt
+    @test [179.5, 86.0] ≈ wcs.crpix
+    @test [0.5, 0.0] ≈ wcs.crval
+
+    shape, wcs = Pixell.slice_geometry(shape0, wcs0, 2:2:shape0[1], 1:12)
+    @test (179, 11) == shape
+    @test [-2.0, 1.0] ≈ wcs.cdelt
+    @test [90.0, 91.0] ≈ wcs.crpix
+    @test [0.5, 0.0] ≈ wcs.crval
+
+    shape, wcs = Pixell.slice_geometry(shape0, wcs0, 23:-4:3, 1:3:31)
+    @test (5, 10) == shape
+    @test [4.0, 3.0] ≈ wcs.cdelt
+    @test [-38.75, 30.666666666666668] ≈ wcs.crpix
+    @test [0.5, 0.0] ≈ wcs.crval
+end
+
 ##
 @testset "Enmap I/O" begin
     imap = read_map("data/test.fits")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,6 +95,66 @@ end
     @test [0.5, 0.0] ≈ wcs.crval
 end
 
+## 
+@testset "Enmap slicing" begin
+    shape0, wcs0 = fullsky_geometry(π/180)
+    m = Enmap(rand(shape0...), wcs0)
+
+    # regular slicing
+    m_sliced = m[5:10, 1:end]
+    wcs = getwcs(m_sliced)
+    @test [-1.0, 1.0] ≈ wcs.cdelt
+    @test [176.5, 91.0] ≈ wcs.crpix
+    @test [0.5, 0.0] ≈ wcs.crval
+    @test (m.data)[5:10, 1:end] ≈ m_sliced
+
+    # backwards slicing
+    m_sliced = m[1:12, end:-1:begin]
+    wcs = getwcs(m_sliced)
+    @test [-1.0, -1.0] ≈ wcs.cdelt
+    @test [180.5, 91.0] ≈ wcs.crpix
+    @test [0.5, 0.0] ≈ wcs.crval
+    @test (m.data)[1:12, end:-1:begin] ≈ m_sliced
+
+    # non-unit steps
+    m_sliced = m[3:5:24, 39:-3:2]
+    wcs = getwcs(m_sliced)
+    @test [-5.0, -3.0] ≈ wcs.cdelt
+    @test [36.1, -16.666666666666668] ≈ wcs.crpix
+    @test [0.5, 0.0] ≈ wcs.crval
+    @test (m.data)[3:5:24, 39:-3:2] ≈ m_sliced
+end
+
+## 
+@testset "Enmap view slicing" begin
+    shape0, wcs0 = fullsky_geometry(π/180)
+    m = Enmap(rand(shape0...), wcs0)
+
+    # regular slicing
+    m_sliced = @view m[5:10, 1:end]
+    wcs = getwcs(m_sliced)
+    @test [-1.0, 1.0] ≈ wcs.cdelt
+    @test [176.5, 91.0] ≈ wcs.crpix
+    @test [0.5, 0.0] ≈ wcs.crval
+    @test (m.data)[5:10, 1:end] ≈ m_sliced
+
+    # backwards slicing
+    m_sliced = @view m[1:12, end:-1:begin]
+    wcs = getwcs(m_sliced)
+    @test [-1.0, -1.0] ≈ wcs.cdelt
+    @test [180.5, 91.0] ≈ wcs.crpix
+    @test [0.5, 0.0] ≈ wcs.crval
+    @test (m.data)[1:12, end:-1:begin] ≈ m_sliced
+
+    # non-unit steps
+    m_sliced = @view m[3:5:24, 39:-3:2]
+    wcs = getwcs(m_sliced)
+    @test [-5.0, -3.0] ≈ wcs.cdelt
+    @test [36.1, -16.666666666666668] ≈ wcs.crpix
+    @test [0.5, 0.0] ≈ wcs.crval
+    @test (m.data)[3:5:24, 39:-3:2] ≈ m_sliced
+end
+
 ##
 @testset "Enmap I/O" begin
     imap = read_map("data/test.fits")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,28 +64,34 @@ end
 ## 
 @testset "slice_geometry" begin
     shape0, wcs0 = fullsky_geometry(deg2rad(1))
-    shape, wcs = slice_geometry(shape0, wcs0, 1:4, 11:-1:2)
+    shape, wcs = slice_geometry(shape0, wcs0, 1:3, 11:-1:3)
     @test (3, 9) == shape
     @test [-1.0, -1.0] ≈ wcs.cdelt
     @test [180.5, -79.0] ≈ wcs.crpix
     @test [0.5, 0.0] ≈ wcs.crval
-    
-    shape, wcs = slice_geometry(shape0, wcs0, 2:shape0[1], 6:12)
-    @test (358, 6) == shape
+
+    shape, wcs = slice_geometry(shape0, wcs0, 2:shape0[1], 6:11)
+    @test (359, 6) == shape
     @test [-1.0, 1.0] ≈ wcs.cdelt
     @test [179.5, 86.0] ≈ wcs.crpix
     @test [0.5, 0.0] ≈ wcs.crval
 
-    shape, wcs = slice_geometry(shape0, wcs0, 2:2:shape0[1], 1:12)
+    shape, wcs = slice_geometry(shape0, wcs0, 2:2:(shape0[1]-1),1:11)
     @test (179, 11) == shape
     @test [-2.0, 1.0] ≈ wcs.cdelt
     @test [90.0, 91.0] ≈ wcs.crpix
     @test [0.5, 0.0] ≈ wcs.crval
 
-    shape, wcs = slice_geometry(shape0, wcs0, 23:-4:3, 1:3:31)
+    shape, wcs = slice_geometry(shape0, wcs0, 23:-4:6, 1:3:28)
     @test (5, 10) == shape
     @test [4.0, 3.0] ≈ wcs.cdelt
     @test [-38.75, 30.666666666666668] ≈ wcs.crpix
+    @test [0.5, 0.0] ≈ wcs.crval
+
+    shape, wcs = slice_geometry(shape0, wcs0, 3:3, 1:3:28)
+    @test (1, 10) == shape
+    @test [-1.0, 3.0] ≈ wcs.cdelt
+    @test [178.5, 30.666666666666668] ≈ wcs.crpix
     @test [0.5, 0.0] ≈ wcs.crval
 end
 


### PR DESCRIPTION
This PR implements the proper WCS modifications one must make when slicing an enmap. This mostly involves modifying the CRPIX entry of the WCS structure. For example,

```julia
using Pixell

shape, wcs = fullsky_geometry(deg2rad(1); dims=(3,) )
m = Enmap(rand(shape...), wcs)
print(m.wcs.crpix, "\n", m[3:20, 50:70, 1].wcs.crpix)
```
```
[180.5, 91.0]
[178.5, 42.0]
```
If the stride is not 1, then CDELT can also change.
```julia
shape, wcs = fullsky_geometry(deg2rad(1))
m = Enmap(rand(shape...), wcs)
print(m.wcs.cdelt, "\n", m[3:5:24, 39:-3:2].wcs.cdelt)
```
```
[-1.0, 1.0]
[-5.0, -3.0]
```
In Julia, there is a syntactical distinction between slicing as copy and slicing as view. The usual array slice always copies! To avoid copies, you have to use `@view` or the `view(...)` function. This PR also provides the appropriate WCS manipulations when a view is made of an Enmap.

```julia
m = Enmap(rand(shape...), wcs)
m_view = @view m[3:24, 80:100]
print(m.wcs.crpix, "\n", m_view.wcs.crpix)
```
```
[180.5, 91.0]
[178.5, 12.0]
```
