### PR TITLE
ensure WCS are not shared during operations

### DIFF
--- a/src/enmap.jl
+++ b/src/enmap.jl
@@ -118,10 +118,10 @@ enmapstyle(x::Broadcast.Unknown) = x
 
 
 struct NoWCS end
-combine(x::NoWCS, y) = y
-combine(x, y::NoWCS) = x
+combine(x::NoWCS, y) = copy(y)
+combine(x, y::NoWCS) = copy(x)
 combine(x::NoWCS, ::NoWCS) = x
-combine(x::WCSTransform, y::WCSTransform) = x  # TODO: check compatibility
+combine(x::WCSTransform, y::WCSTransform) = copy(x)  # TODO: check compatibility
 
 
 ####
@@ -184,8 +184,11 @@ function Base.copy(bc::Broadcast.Broadcasted{<:EnmapStyle{S}}) where {S}
     # argument contains the meta data
     args_ = (bc.args[1][2], Base.tail(bc.args)...)
     bc_ = Broadcast.Broadcasted{S}(bc.f, args_, bc.axes)
-    Enmap(copy(bc_), bc.args[1][1])
+    Enmap(copy(bc_), copy(bc.args[1][1]))
 end
+
+
+Base.deepcopy(x::Enmap) = Enmap(deepcopy(parent(x)), deepcopy(getwcs(x)))
 
 
 function Base.show(io::IO, imap::Enmap)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,6 +155,29 @@ end
     @test (m.data)[3:5:24, 39:-3:2] ≈ m_sliced
 end
 
+## WCS should be not be shared under deepcopy, broadcasting, or broadcasted assignment
+@testset "Enmap copying behavior" begin  
+    shape0, wcs0 = fullsky_geometry(π/180)
+    m = Enmap(rand(shape0...), wcs0)
+    m2 = deepcopy(m)
+    @test !(m.wcs === m2.wcs)
+    m2.wcs.cdelt = [99., 99.]
+    @test !(m.wcs.cdelt ≈ [99., 99.])
+
+    m = Enmap(rand(shape0...), wcs0)
+    m2 = m.^2
+    @test !(m.wcs === m2.wcs)
+    m2.wcs.cdelt = [99., 99.]
+    @test !(m.wcs.cdelt ≈ [99., 99.])
+
+    m = Enmap(rand(shape0...), wcs0)
+    m2 = deepcopy(m)
+    m2 .= m
+    @test !(m.wcs === m2.wcs)
+    m2.wcs.cdelt = [99., 99.]  # also make sure sub-arrays aren't shared
+    @test !(m.wcs.cdelt ≈ [99., 99.])
+end
+
 ##
 @testset "Enmap I/O" begin
     imap = read_map("data/test.fits")


### PR DESCRIPTION
This fixes a bug with broadcasting, where the result Enmap would have the same WCS object as the leftmost Enmap in an expression. 

This fix makes a copy of the WCS every time there is an operation. This incurs a slight performance penalty, but is challenging to avoid. Broadcasting on Enmap directly will be ~5% slower than working with the parent array, but I think that's pretty hard to notice.