### PR TITLE
add basic plotting utilities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,8 @@ authors = ["Zack Li", "Yilun Guan"]
 version = "0.1.0"
 
 [deps]
+ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FITSIO = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
@@ -13,6 +15,7 @@ Libsharp = "ac8d63fe-4615-43ae-9860-9cd4a3820532"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAngles = "6fb2a4bd-7999-5318-a3b2-8ad61056cd98"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 WCS = "15f3aee2-9e10-537f-b834-a6fb8bdb944d"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -13,18 +13,18 @@ FastTransforms = "057dd010-8810-581a-b7be-e3fc3b93f78c"
 Healpix = "9f4e344d-96bc-545a-84a3-ae6b9e1b672b"
 Libsharp = "ac8d63fe-4615-43ae-9860-9cd4a3820532"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAngles = "6fb2a4bd-7999-5318-a3b2-8ad61056cd98"
-RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 WCS = "15f3aee2-9e10-537f-b834-a6fb8bdb944d"
 
 [compat]
 DSP = "0.7"
 FFTW = "1"
 FITSIO = "0.16"
-Libsharp = "0.2"
-Healpix = "3"
 FastTransforms = "0.13"
+Healpix = "3"
+Libsharp = "0.2"
 Unitful = "1"
 UnitfulAngles = "0.5, 0.6"
 WCS = "0.6.1"
@@ -33,6 +33,7 @@ julia = "1.6"
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [targets]
-test = ["Test", "DelimitedFiles"]
+test = ["Test", "DelimitedFiles", "Plots"]

--- a/src/Pixell.jl
+++ b/src/Pixell.jl
@@ -29,4 +29,6 @@ const radian = Unitful.rad
 const degree = Unitful.°
 const arcminute = UnitfulAngles.arcminute
 
+include("plot.jl")
+
 end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1,8 +1,8 @@
 module Enplot
 
-using Colors
+using Colors: RGB, weighted_color_mean
 using RecipesBase
-using ColorSchemes: ColorScheme
+using ColorSchemes
 
 import Pixell: Enmap, pix2sky
 
@@ -21,14 +21,16 @@ function build_colorscheme(colors, locs)
 end
 
 # here we define some common color schemes
-colorschemes = Dict{Symbol,ColorScheme}()
-colorschemes[:planck] = build_colorscheme([rgb(0, 0, 255), rgb(0, 215, 255), rgb(255, 237, 217), rgb(255, 180, 0), rgb(255, 75, 0), rgb(100, 0, 0)], [0, 0.332, 0.5, 0.664, 0.828, 1])
+cschemes = Dict{Symbol,ColorScheme}()
+cschemes[:planck] = build_colorscheme([rgb(0, 0, 255), rgb(0, 215, 255), rgb(255, 237, 217), rgb(255, 180, 0), rgb(255, 75, 0), rgb(100, 0, 0)], [0, 0.332, 0.5, 0.664, 0.828, 1])
 
-function register_colorschemes!(cschemes)
-    for (k, v) in colorschemes
-        cschemes[k] = v
+function register_colors!()
+    for (k, v) in cschemes
+        ColorSchemes.colorschemes[k] = v
     end
 end
+
+export register_colors!
 
 # here we define common plot recipes
 @recipe function f(imap::Enmap)
@@ -36,7 +38,7 @@ end
     aspect_ratio := :equal
     xformatter   := x -> pix2sky_formatter(x, imap)
     yformatter   := x -> pix2sky_formatter(x, imap; ind=2)
-    color          --> :planck  # need to call register colorschemes first
+    color          --> :greys
     xlim           --> (1, size(imap.data,1))  # not nice
     ylim           --> (1, size(imap.data,2))
     colorbar       --> false

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1,0 +1,56 @@
+module Enplot
+
+using Colors
+using RecipesBase
+using ColorSchemes: ColorScheme
+
+import Pixell: Enmap, pix2sky
+
+# convert 0:255 integer to 0:1 Float64
+rgb(c...) = RGB{Float64}((c./255)...)
+
+# build a ColorScheme based on a list of colors and their locations in
+# 0:1 colormap
+function build_colorscheme(colors, locs)
+    xs = collect(0:0.01:1)
+    map(xs) do x
+        i = min(findlast((<=)(x), locs), length(locs)-1)
+        r = (x-locs[i])/(locs[i+1]-locs[i])
+        weighted_color_mean(1-r, colors[i], colors[i+1])
+    end |> ColorScheme
+end
+
+# here we define some common color schemes
+colorschemes = Dict{Symbol,ColorScheme}()
+colorschemes[:planck] = build_colorscheme([rgb(0, 0, 255), rgb(0, 215, 255), rgb(255, 237, 217), rgb(255, 180, 0), rgb(255, 75, 0), rgb(100, 0, 0)], [0, 0.332, 0.5, 0.664, 0.828, 1])
+
+function register_colorschemes!(cschemes)
+    for (k, v) in colorschemes
+        cschemes[k] = v
+    end
+end
+
+# here we define common plot recipes
+@recipe function f(imap::Enmap)
+    seriestype   := :heatmap
+    aspect_ratio := :equal
+    xformatter   := x -> pix2sky_formatter(x, imap)
+    yformatter   := x -> pix2sky_formatter(x, imap; ind=2)
+    color          --> :planck  # need to call register colorschemes first
+    xlim           --> (1, size(imap.data,1))  # not nice
+    ylim           --> (1, size(imap.data,2))
+    colorbar       --> false
+    minorticks     --> true
+    tick_direction --> :out
+    grid           --> false
+
+    imap.data
+end
+
+# format pixel index with its sky coordinate. ra: ind=1, dec: ind=2
+function pix2sky_formatter(x, imap::Enmap; ind=1, digits=2)
+    res = round(pix2sky(imap, float.([x, x]))[ind], digits=digits)
+    imap.wcs.cunit[1] == "deg" ? string(res)*"°" : res[1]
+end
+
+end  # module

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -41,12 +41,12 @@ export register_colors!
     color          --> :greys
     xlim           --> (1, size(imap.data,1))  # not nice
     ylim           --> (1, size(imap.data,2))
-    colorbar       --> false
+    colorbar       --> true
     minorticks     --> true
     tick_direction --> :out
     grid           --> false
 
-    imap.data
+    imap.data'
 end
 
 # format pixel index with its sky coordinate. ra: ind=1, dec: ind=2

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -49,8 +49,8 @@ end
 
 # format pixel index with its sky coordinate. ra: ind=1, dec: ind=2
 function pix2sky_formatter(x, imap::Enmap; ind=1, digits=2)
-    res = round(pix2sky(imap, float.([x, x]))[ind], digits=digits)
-    imap.wcs.cunit[1] == "deg" ? string(res)*"°" : res[1]
+    res = round(rad2deg(pix2sky(imap, float.([x, x]))[ind]), digits=digits)
+    string(res)*"°"
 end
 
 end  # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,3 +8,4 @@ include("test_geometry.jl")  # creating geometries and sky ↔ pix
 include("test_enmap.jl")     # enmap features and manipulation
 include("test_transforms.jl")
 include("test_io.jl")
+include("test_plot.jl")

--- a/test/test_plot.jl
+++ b/test/test_plot.jl
@@ -1,0 +1,7 @@
+@testset "Enmap plot" begin
+    using Plots; gr()
+    using Pixell.Enplot
+    register_colors!()
+    imap = read_map("data/test.fits", sel=(:,:,1))
+    @test (plot(imap, color=:planck); true)
+end


### PR DESCRIPTION
This PR will allow `plot(enmap)` to behave properly, with some reasonable defaults. It also includes a planck colorscheme taken from pixell. Since it is a well isolated part of the package, I made it a submodule. 