### PR TITLE
broadcasting assignment

### DIFF
--- a/src/enmap.jl
+++ b/src/enmap.jl
@@ -58,6 +58,11 @@ end
     Enmap(view(parent(x), idxs...), new_wcs)
 end
 
+# totally give up if the RA and DEC slices are eliminated, and just return a view of the parent
+@propagate_inbounds Base.view(x::Enmap, ix::Integer, idxs...) = view(parent(x), ix, idxs...)
+@propagate_inbounds Base.view(x::Enmap, ix, iy::Integer, idxs...) = view(parent(x), ix, iy, idxs...)
+
+
 @propagate_inbounds Base.getindex(x::Enmap, i::Int...) = getindex(parent(x), i...)
 @propagate_inbounds function Base.getindex(x::Enmap, i...)
     enmapwrap(x, getindex(parent(x), i...), i...)

--- a/src/enmap.jl
+++ b/src/enmap.jl
@@ -80,14 +80,8 @@ function enmapwrap(x::Enmap{T,N,AA,P}, val::AAV, i...) where {T,N,AA,P,NV,AAV<:A
     Enmap{T,NV,AAV,P}(val, new_wcs)
 end
 
-
-# disable reducing dimension along the first two axes. should do more testing on this
-throw_1d_error() = error("An Enmap needs two WCS axes, for now. If you want a row, use a range i.e. enmap[5:5, :]")
-enmapwrap(x::Enmap{T,N,AA,P}, val::AAV, i1::Int, i...) where {T,N,AA,P,NV,AAV<:AbstractArray{T,NV}} =
-    throw_1d_error()
-enmapwrap(x::Enmap{T,N,AA,P}, val::AAV, i1, i2::Int, i...) where {T,N,AA,P,NV,AAV<:AbstractArray{T,NV}} =
-    throw_1d_error()
-
+enmapwrap(x::Enmap{T,N,AA,P}, val::AAV, i1::Int, i...) where {T,N,AA,P,NV,AAV<:AbstractArray{T,NV}} = val
+enmapwrap(x::Enmap{T,N,AA,P}, val::AAV, i1, i2::Int, i...) where {T,N,AA,P,NV,AAV<:AbstractArray{T,NV}} = val
 enmapwrap(x, val, i...) = error("Unexpected result type $(typeof(val)).")
 
 Base.strides(x::Enmap) = strides(parent(x))

--- a/src/enmap.jl
+++ b/src/enmap.jl
@@ -28,8 +28,11 @@ function Enmap(data::A, wcs) where {A<:AbstractArray}
     Enmap{eltype(A),ndims(A),A,CarClenshawCurtis}(data, wcs)
 end
 
+struct NoWCS end
+
 Base.parent(x::Enmap) = x.data
 getwcs(x::Enmap) = x.wcs
+getwcs(x) = NoWCS()
 
 # retrieve nonallocating WCS information. returns tuples of cdelt, crval, crpix
 cdelt(wcs::WCSTransform) = unsafe_load(WCS.getfield(wcs, :cdelt), 1), 
@@ -116,7 +119,6 @@ enmapstyle(x) = EnmapStyle(x)
 enmapstyle(x::Broadcast.Unknown) = x
 
 
-struct NoWCS end
 combine(x::NoWCS, y) = copy(y)
 combine(x, y::NoWCS) = copy(x)
 combine(x::NoWCS, ::NoWCS) = x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,7 +53,11 @@ end
     @test Pixell.getwcs(mv) == Pixell.NoWCS()
     mv = ma[1,:,1]
     @test Pixell.getwcs(mv) == Pixell.NoWCS()
+    mv = ma[1,:,:]
+    @test Pixell.getwcs(mv) == Pixell.NoWCS()
     mv = ma[1:5,:,1]
+    @test Pixell.getwcs(mv) != Pixell.NoWCS()
+    mv = ma[1:5,:,:]
     @test Pixell.getwcs(mv) != Pixell.NoWCS()
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,15 @@ end
     @test A .+ B == ma .+ B
     @test A .+ B == A .+ mb
     @test A .+ B .* sin.(A.^2) == (ma .+ mb .* sin.(ma.^2))
+
+    ma .= 1.0
+    @test all(ma .≈ 1.0)
+    ma .= mb
+    @test all(ma .≈ mb)
+    ma[1,:,3] .= 2.0
+    @test all(ma[1,:,3] .≈ 2.0)
+    ma[:,end,3] .= 3.0
+    @test all(ma[:,end,3] .≈ 3.0)
 end
 
 ##

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,18 @@ end
     @test all(ma[1,:,3] .≈ 2.0)
     ma[:,end,3] .= 3.0
     @test all(ma[:,end,3] .≈ 3.0)
+    ma[:,1,:] .= mb[:,2,:]
+    @test all(ma.data[:,1,:] .≈ mb.data[:,2,:])
+
+    A, B = rand(shape...), rand(shape...)
+    ma = Enmap(A, wcs)
+    mb = Enmap(B, wcs)
+    mb[:,:,1] .= ma[:,:,1]
+    @test all(ma.data[:,:,1] .≈ mb.data[:,:,1])
+    @test !all(ma.data[:,:,2] .≈ mb.data[:,:,2])
+    @test !all(ma.data[:,:,3] .≈ mb.data[:,:,3])
+    mb[:,:,:] .= ma[:,:,:]
+    @test all(ma.data .≈ mb.data)
 end
 
 ##

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,13 @@ end
     @test !all(ma.data[:,:,3] .≈ mb.data[:,:,3])
     mb[:,:,:] .= ma[:,:,:]
     @test all(ma.data .≈ mb.data)
+
+    mv = @view ma[1,:,1]
+    @test Pixell.getwcs(mv) == Pixell.NoWCS()
+    mv = ma[1,:,1]
+    @test Pixell.getwcs(mv) == Pixell.NoWCS()
+    mv = ma[1:5,:,1]
+    @test Pixell.getwcs(mv) != Pixell.NoWCS()
 end
 
 ##


### PR DESCRIPTION
Didn't have tests for sliced broadcast assignment. This PR will add support for assignment to axes of Enmap.

I've decided to just follow python pixell: any time one of the dimensions corresponding to one of the WCS axes is eliminated (such as when it is indexed in a slice), we strip the WCS information and perform the slice on the parent.

```julia
m[1, :] .= ones(size(m, 2))
```