### PR TITLE
"safe" wrapping behavior

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,6 @@ WCS = "15f3aee2-9e10-537f-b834-a6fb8bdb944d"
 FFTW = "1"
 FITSIO = "0.16"
 WCS = "0.6"
-DSP = "0.7"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Zack Li", "Yilun Guan"]
 version = "0.1.0"
 
 [deps]
+DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FITSIO = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -13,6 +14,7 @@ WCS = "15f3aee2-9e10-537f-b834-a6fb8bdb944d"
 FFTW = "1"
 FITSIO = "0.16"
 WCS = "0.6"
+DSP = "0.7"
 julia = "1.6"
 
 [extras]

--- a/src/Pixell.jl
+++ b/src/Pixell.jl
@@ -4,7 +4,7 @@ using WCS
 using FITSIO
 using FFTW
 using Printf
-using DSP: unwrap
+using DSP: unwrap, unwrap!
 
 include("enmap.jl")
 include("enmap_ops.jl")

--- a/src/Pixell.jl
+++ b/src/Pixell.jl
@@ -4,6 +4,7 @@ using WCS
 using FITSIO
 using FFTW
 using Printf
+using DSP: unwrap
 
 include("enmap.jl")
 include("enmap_ops.jl")

--- a/src/enmap_ops.jl
+++ b/src/enmap_ops.jl
@@ -72,7 +72,7 @@ end
 
 function unwind(angles; dims=nothing, period=2π, ref_angle=0)
     wound_angles = rewind(angles; period=period, ref_angle=ref_angle)
-    return unwrap(angles .- ref_angle; dims=dims, range=period) .+ ref_angle
+    return unwrap(wound_angles .- ref_angle; dims=dims, range=period) .+ ref_angle
 end
 
 function unwind!(angles; dims=nothing, period=2π, ref_angle=0)

--- a/src/enmap_ops.jl
+++ b/src/enmap_ops.jl
@@ -52,18 +52,37 @@ fullsky_geometry(res; shape = nothing, dims = ()) =
 
 
 """
-    rewrap(angles, period=2π, ref_angle=0)
+    rewind(angles, period=2π, ref_angle=0)
 
 Given angles or other cyclic coordinates with the specified period, such that
 the angle + period has the same meaning as the original angle, this function adds or subtracts 
 multiples of the period such that the result has the same meaning, but now all angles lie in
 an interval of length the specified period, centered on the reference angle `ref_angle`.
 """
-function rewrap(angles, period=2π, ref_angle=0)
+function rewind(angles; period=2π, ref_angle=0)
     half_period = period / 2
     return ref_angle .+ mod.(angles .- ref_angle .+ half_period, period) .- half_period
 end
-# the counterpart, unwrap, is provided by DSP.jl
+
+function rewind!(angles; period=2π, ref_angle=0)
+    half_period = period / 2
+    angles .= ref_angle .+ mod.(angles .- ref_angle .+ half_period, period) .- half_period
+    return angles
+end
+
+function unwind(angles; dims=nothing, period=2π, ref_angle=0)
+    wound_angles = rewind(angles; period=period, ref_angle=ref_angle)
+    return unwrap(angles .- ref_angle; dims=dims, range=period) .+ ref_angle
+end
+
+function unwind!(angles; dims=nothing, period=2π, ref_angle=0)
+    rewind!(angles; period=period, ref_angle=ref_angle)
+    angles .-= ref_angle
+    unwrap!(angles; dims=dims, range=period)
+    angles .+= ref_angle
+    return angles
+end
+
 
 """
     pix2sky(m::Enmap, pixcoords)
@@ -94,23 +113,48 @@ function pix2sky end
 ## The default fallback (no projection specified) is to call WCS, which calls the C library.
 ## If you wanted to replicate Pixell behavior, add 1 to x and y of pixcoords.
 ## We implement custom routines for CAR (Clenshaw-Curtis variant) instead of using these.
-function pix2sky(m::Enmap{T}, pixcoords) where T
-    angle_unit = get_unit(T, w)
-    return pix_to_world(getwcs(m), pixcoords) .* angle_unit
-end
-function pix2sky!(m::Enmap{T}, pixcoords, skycoords) where T
-    angle_unit = get_unit(T, w)
-    pix_to_world!(getwcs(m), pixcoords, skycoords)
-    skycoords .*= angle_unit
+function pix2sky(m::Enmap{T}, pixcoords; safe=true) where T
+    wcs_m = getwcs(m)
+    angle_unit = get_unit(T, wcs_m)
+    skycoords = pix_to_world(wcs_m, pixcoords) .* angle_unit
+    if safe
+        return unwind(skycoords; dims=2)
+    end
     return skycoords
 end
-function sky2pix(m::Enmap{T}, skycoords) where T
-    inverse_angle_unit = 1 / get_unit(T, w)
-    return world_to_pix(getwcs(m), skycoords .* inverse_angle_unit)
+function pix2sky!(m::Enmap{T}, pixcoords, skycoords; safe=true) where T
+    wcs_m = getwcs(m)
+    angle_unit = get_unit(T, wcs_m)
+    pix_to_world!(getwcs(m), pixcoords, skycoords)
+    skycoords .*= angle_unit
+    if safe
+        unwind!(skycoords; dims=2)
+    end
+    return skycoords
 end
-function sky2pix!(m::Enmap{T}, skycoords, pixcoords) where T
-    inverse_angle_unit = 1 / get_unit(T, w)
-    return world_to_pix!(getwcs(m), skycoords .* inverse_angle_unit, pixcoords)
+function sky2pix(m::Enmap{T}, skycoords; safe=true) where T
+    wcs_m = getwcs(m)
+    inverse_angle_unit = 1 / get_unit(T, wcs_m)
+    pixcoords = world_to_pix(getwcs(m), skycoords .* inverse_angle_unit)
+    if safe
+        center_pix = size(m)[1:2] ./ 2
+        pix_periods = abs.(2π ./ (cdelt(wcs_m)  .* inverse_angle_unit))
+        rewind!(view(pixcoords, 1, :); period=pix_periods[1], ref_angle=center_pix[1])
+        rewind!(view(pixcoords, 2, :); period=pix_periods[2], ref_angle=center_pix[2])
+    end
+    return pixcoords
+end
+function sky2pix!(m::Enmap{T}, skycoords, pixcoords; safe=true) where T
+    wcs_m = getwcs(m)
+    inverse_angle_unit = 1 / get_unit(T, wcs_m)
+    world_to_pix!(getwcs(m), skycoords .* inverse_angle_unit, pixcoords)
+    if safe
+        center_pix = size(m)[1:2] ./ 2
+        pix_periods = abs.(2π ./ (cdelt(wcs_m)  .* inverse_angle_unit))
+        rewind!(view(pixcoords, 1, :); period=pix_periods[1], ref_angle=center_pix[1])
+        rewind!(view(pixcoords, 2, :); period=pix_periods[2], ref_angle=center_pix[2])
+    end
+    return pixcoords
 end
 
 """
@@ -139,15 +183,15 @@ julia> pix2sky!(m, pixcoords, skycoords)
 ```
 """
 function pix2sky!(m::Enmap{T,N,AA,CarClenshawCurtis},
-    pixcoords::AbstractArray{TP,2}, skycoords::AbstractArray{TS,2}
+    pixcoords::AbstractArray{TP,2}, skycoords::AbstractArray{TS,2}; safe=true
 ) where {T,N,AA<:AbstractArray{T,N},TP,TS}
 
     # retrieve WCS info
-    w = getwcs(m)
-    angle_unit = get_unit(T, w)
-    α₀, δ₀ = crval(w) .* angle_unit
-    Δα, Δδ = cdelt(w) .* angle_unit
-    iα₀, iδ₀ = crpix(w)
+    wcs_m = getwcs(m)
+    angle_unit = get_unit(T, wcs_m)
+    α₀, δ₀ = crval(wcs_m) .* angle_unit
+    Δα, Δδ = cdelt(wcs_m) .* angle_unit
+    iα₀, iδ₀ = crpix(wcs_m)
 
     # compute RA (α) and DEC (δ)
     @inbounds for ipix ∈ axes(pixcoords, 2)
@@ -158,15 +202,19 @@ function pix2sky!(m::Enmap{T,N,AA,CarClenshawCurtis},
         skycoords[1, ipix] = α
         skycoords[2, ipix] = δ
     end
+    
+    if safe
+        unwind!(skycoords; dims=2)
+    end
 
     return skycoords
 end
 
 # the not-in-place version just creates an output array and calls the in-place one above
-function pix2sky(m::Enmap{T,N,AA,CarClenshawCurtis}, pixcoords::AbstractArray{TP,2}
+function pix2sky(m::Enmap{T,N,AA,CarClenshawCurtis}, pixcoords::AbstractArray{TP,2}; safe=true
 ) where {T,N,AA<:AbstractArray{T,N},TP}
     skycoords = similar(pixcoords)
-    return pix2sky!(m, pixcoords, skycoords)
+    return pix2sky!(m, pixcoords, skycoords; safe=safe)
 end
 
 """
@@ -188,33 +236,29 @@ julia> pix2sky(m, 30.0, 80.0)
 ```
 """
 function pix2sky(m::Enmap{T,N,AA,CarClenshawCurtis}, 
-                 ra_pixel::Number, dec_pixel::Number) where {T,N,AA<:AbstractArray{T,N}}
-    w = getwcs(m)
-    angle_unit = get_unit(T, w)
-    α₀, δ₀ = crval(w) .* angle_unit
-    Δα, Δδ = cdelt(w) .* angle_unit
-    iα₀, iδ₀ = crpix(w)
-    α = α₀ + (ra_pixel - iα₀) * Δα
-    δ = δ₀ + (dec_pixel - iδ₀) * Δδ
-    return α, δ
-end
-function pix2sky(m::Enmap{T,N,AA,CarClenshawCurtis}, 
-                 ra_pixel::AV, dec_pixel::AV) where {T,N,AA<:AbstractArray{T,N}, AV<:AbstractVector}
-    w = getwcs(m)
-    angle_unit = get_unit(T, w)
-    α₀, δ₀ = crval(w) .* angle_unit
-    Δα, Δδ = cdelt(w) .* angle_unit
-    iα₀, iδ₀ = crpix(w)
+                 ra_pixel, dec_pixel; safe=true) where {T,N,AA<:AbstractArray{T,N}}
+    wcs_m = getwcs(m)
+    angle_unit = get_unit(T, wcs_m)
+    α₀, δ₀ = crval(wcs_m) .* angle_unit
+    Δα, Δδ = cdelt(wcs_m) .* angle_unit
+    iα₀, iδ₀ = crpix(wcs_m)
     α = α₀ .+ (ra_pixel .- iα₀) .* Δα
     δ = δ₀ .+ (dec_pixel .- iδ₀) .* Δδ
+    if safe
+        return rewind(α), rewind(δ)
+    end
     return α, δ
 end
 
 # when passing a length-2 vector [ra, dec], return a vector. wraps the pix2sky(m, ra_pix, dec_pix)
 function pix2sky(m::Enmap{T,N,AA,CarClenshawCurtis}, 
-                 pixcoords::AbstractVector) where {T,N,AA<:AbstractArray{T,N}}
+                 pixcoords::AbstractVector; safe=true) where {T,N,AA<:AbstractArray{T,N}}
     @assert length(pixcoords) == 2
-    return collect(pix2sky(m, first(pixcoords), last(pixcoords)))
+    skycoords = collect(pix2sky(m, first(pixcoords), last(pixcoords)))
+    if safe
+        unwind!(skycoords; dims=2)
+    end
+    return skycoords
 end
 
 
@@ -269,14 +313,14 @@ julia> sky2pix!(m, skycoords, pixcoords)
 ```
 """
 function sky2pix!(m::Enmap{T,N,AA,CarClenshawCurtis}, skycoords::AbstractArray{TS,2}, 
-                  pixcoords::AbstractArray{TP,2}) where {T,N,AA<:AbstractArray{T,N},TS,TP}
+                  pixcoords::AbstractArray{TP,2}; safe=true) where {T,N,AA<:AbstractArray{T,N},TS,TP}
 
     # retrieve WCS info
-    w = getwcs(m)
-    angle_unit = get_unit(T, w)
-    α₀, δ₀ = crval(w) .* angle_unit
-    Δα, Δδ = cdelt(w) .* angle_unit
-    iα₀, iδ₀ = crpix(w)
+    wcs_m = getwcs(m)
+    angle_unit = get_unit(T, wcs_m)
+    α₀, δ₀ = crval(wcs_m) .* angle_unit
+    Δα, Δδ = cdelt(wcs_m) .* angle_unit
+    iα₀, iδ₀ = crpix(wcs_m)
     Δα⁻¹, Δδ⁻¹ = 1 / Δα, 1 / Δδ
 
     # compute RA (α) index and DEC (δ) index
@@ -289,14 +333,21 @@ function sky2pix!(m::Enmap{T,N,AA,CarClenshawCurtis}, skycoords::AbstractArray{T
         pixcoords[2, ipix] = iδ
     end
 
+    if safe
+        center_pix = size(m)[1:2] ./ 2
+        pix_periods = abs.(2π ./ (cdelt(wcs_m)  ./ angle_unit))
+        rewind!(view(pixcoords, 1, :); period=pix_periods[1], ref_angle=center_pix[1])
+        rewind!(view(pixcoords, 2, :); period=pix_periods[2], ref_angle=center_pix[2])
+    end
+
     return pixcoords
 end
 
 # the not-in-place version just creates an output array and calls the in-place one above
 function sky2pix(m::Enmap{T,N,AA,CarClenshawCurtis}, 
-                 skycoords::AbstractArray{TS,2}) where {T,N,AA<:AbstractArray{T,N},TS}
+                 skycoords::AbstractArray{TS,2}; safe=true) where {T,N,AA<:AbstractArray{T,N},TS}
     pixcoords = similar(skycoords)
-    return sky2pix!(m, skycoords, pixcoords)
+    return sky2pix!(m, skycoords, pixcoords; safe=safe)
 end
 
 
@@ -319,34 +370,47 @@ julia> sky2pix(m, 30.0, 80.0)
 ```
 """
 function sky2pix(m::Enmap{T,N,AA,CarClenshawCurtis}, 
-                 ra::Number, dec::Number) where {T,N,AA<:AbstractArray{T,N}}
-    w = getwcs(m)
-    angle_unit = get_unit(T, w)
-    α₀, δ₀ = crval(w) .* angle_unit
-    Δα, Δδ = cdelt(w) .* angle_unit
-    iα₀, iδ₀ = crpix(w)
+                 ra::Number, dec::Number; safe=true) where {T,N,AA<:AbstractArray{T,N}}
+    wcs_m = getwcs(m)
+    angle_unit = get_unit(T, wcs_m)
+    α₀, δ₀ = crval(wcs_m) .* angle_unit
+    Δα, Δδ = cdelt(wcs_m) .* angle_unit
+    iα₀, iδ₀ = crpix(wcs_m)
     pix_ra = iα₀ + (ra - α₀) / Δα
     pix_dec = iδ₀ + (dec - δ₀) / Δδ
+
+    if safe
+        center_pix = size(m)[1:2] ./ 2
+        pix_ra = rewind(pix_ra; period=2π / Δα, ref_angle=center_pix[1])
+        pix_dec = rewind(pix_dec; period=2π / Δδ, ref_angle=center_pix[2])
+    end
     return pix_ra, pix_dec
 end
 function sky2pix(m::Enmap{T,N,AA,CarClenshawCurtis}, 
                  ra::AV, dec::AV) where {T,N,AA<:AbstractArray{T,N}, AV<:AbstractVector}
-    w = getwcs(m)
-    angle_unit = get_unit(T, w)
-    α₀, δ₀ = crval(w) .* angle_unit
-    Δα, Δδ = cdelt(w) .* angle_unit
-    iα₀, iδ₀ = crpix(w)
+    wcs_m = getwcs(m)
+    angle_unit = get_unit(T, wcs_m)
+    α₀, δ₀ = crval(wcs_m) .* angle_unit
+    Δα, Δδ = cdelt(wcs_m) .* angle_unit
+    iα₀, iδ₀ = crpix(wcs_m)
     Δα⁻¹, Δδ⁻¹ = 1 / Δα, 1 / Δδ
     pix_ra = iα₀ .+ (ra .- α₀) .* Δα⁻¹
     pix_dec = iδ₀ .+ (dec .- δ₀) .* Δδ⁻¹
+    
+    if safe
+        center_pix = size(m)[1:2] ./ 2
+        rewind!(pix_ra; period=(2π * Δα⁻¹), ref_angle=center_pix[1])
+        rewind!(pix_dec; period=(2π * Δδ⁻¹), ref_angle=center_pix[2])
+    end
+
     return pix_ra, pix_dec
 end
 
 # when passing a vector [ra, dec], return a vector. wraps the sky2pix(m, ra, dec).
 function sky2pix(m::Enmap{T,N,AA,CarClenshawCurtis},
-                 skycoords::AbstractVector) where {T,N,AA<:AbstractArray{T,N}}
+                 skycoords::AbstractVector; safe=true) where {T,N,AA<:AbstractArray{T,N}}
     @assert length(skycoords) == 2
-    return collect(sky2pix(m, first(skycoords), last(skycoords)))
+    return collect(sky2pix(m, first(skycoords), last(skycoords); safe=safe))
 end
 
 # this set of slices is necessary because colons are somehow not expanded

--- a/src/enmap_ops.jl
+++ b/src/enmap_ops.jl
@@ -139,7 +139,7 @@ function sky2pix(m::Enmap{T}, skycoords; safe=true) where T
     pixcoords = world_to_pix(getwcs(m), skycoords .* inverse_angle_unit)
     if safe
         center_pix = size(m)[1:2] ./ 2
-        pix_periods = abs.(2π ./ (cdelt(wcs_m)  .* angle_unit))
+        pix_periods = abs.(2π ./ (cdelt(wcs_m) .* angle_unit))
         rewind!(view(pixcoords, 1, :); period=pix_periods[1], ref_angle=center_pix[1])
         rewind!(view(pixcoords, 2, :); period=pix_periods[2], ref_angle=center_pix[2])
     end
@@ -152,7 +152,7 @@ function sky2pix!(m::Enmap{T}, skycoords, pixcoords; safe=true) where T
     world_to_pix!(getwcs(m), skycoords .* inverse_angle_unit, pixcoords)
     if safe
         center_pix = size(m)[1:2] ./ 2
-        pix_periods = abs.(2π ./ (cdelt(wcs_m)  .* inverse_angle_unit))
+        pix_periods = abs.(2π ./ (cdelt(wcs_m) .* angle_unit))
         rewind!(view(pixcoords, 1, :); period=pix_periods[1], ref_angle=center_pix[1])
         rewind!(view(pixcoords, 2, :); period=pix_periods[2], ref_angle=center_pix[2])
     end
@@ -337,7 +337,7 @@ function sky2pix!(m::Enmap{T,N,AA,CarClenshawCurtis}, skycoords::AbstractArray{T
 
     if safe
         center_pix = size(m)[1:2] ./ 2
-        pix_periods = abs.(2π ./ (cdelt(wcs_m)  ./ angle_unit))
+        pix_periods = abs.(2π ./ (Δα, Δδ))
         rewind!(view(pixcoords, 1, :); period=pix_periods[1], ref_angle=center_pix[1])
         rewind!(view(pixcoords, 2, :); period=pix_periods[2], ref_angle=center_pix[2])
     end

--- a/src/enmap_ops.jl
+++ b/src/enmap_ops.jl
@@ -134,11 +134,12 @@ function pix2sky!(m::Enmap{T}, pixcoords, skycoords; safe=true) where T
 end
 function sky2pix(m::Enmap{T}, skycoords; safe=true) where T
     wcs_m = getwcs(m)
-    inverse_angle_unit = 1 / get_unit(T, wcs_m)
+    angle_unit = get_unit(T, wcs_m)
+    inverse_angle_unit = 1 / angle_unit
     pixcoords = world_to_pix(getwcs(m), skycoords .* inverse_angle_unit)
     if safe
         center_pix = size(m)[1:2] ./ 2
-        pix_periods = abs.(2π ./ (cdelt(wcs_m)  .* inverse_angle_unit))
+        pix_periods = abs.(2π ./ (cdelt(wcs_m)  .* angle_unit))
         rewind!(view(pixcoords, 1, :); period=pix_periods[1], ref_angle=center_pix[1])
         rewind!(view(pixcoords, 2, :); period=pix_periods[2], ref_angle=center_pix[2])
     end
@@ -146,7 +147,8 @@ function sky2pix(m::Enmap{T}, skycoords; safe=true) where T
 end
 function sky2pix!(m::Enmap{T}, skycoords, pixcoords; safe=true) where T
     wcs_m = getwcs(m)
-    inverse_angle_unit = 1 / get_unit(T, wcs_m)
+    angle_unit = get_unit(T, wcs_m)
+    inverse_angle_unit = 1 / angle_unit
     world_to_pix!(getwcs(m), skycoords .* inverse_angle_unit, pixcoords)
     if safe
         center_pix = size(m)[1:2] ./ 2

--- a/src/enmap_ops.jl
+++ b/src/enmap_ops.jl
@@ -52,6 +52,20 @@ fullsky_geometry(res; shape = nothing, dims = ()) =
 
 
 """
+    rewrap(angles, period=2π, ref_angle=0)
+
+Given angles or other cyclic coordinates with the specified period, such that
+the angle + period has the same meaning as the original angle, this function adds or subtracts 
+multiples of the period such that the result has the same meaning, but now all angles lie in
+an interval of length the specified period, centered on the reference angle `ref_angle`.
+"""
+function rewrap(angles, period=2π, ref_angle=0)
+    half_period = period / 2
+    return ref_angle .+ mod.(angles .- ref_angle .+ half_period, period) .- half_period
+end
+# the counterpart, unwrap, is provided by DSP.jl
+
+"""
     pix2sky(m::Enmap, pixcoords)
 
 Convert 1-indexed pixels to sky coordinates. The output sky coordinates are determined by WCS,

--- a/src/enmap_ops.jl
+++ b/src/enmap_ops.jl
@@ -138,7 +138,7 @@ function sky2pix(m::Enmap{T}, skycoords; safe=true) where T
     inverse_angle_unit = 1 / angle_unit
     pixcoords = world_to_pix(getwcs(m), skycoords .* inverse_angle_unit)
     if safe
-        center_pix = size(m)[1:2] ./ 2
+        center_pix = size(m)[1:2] ./ 2 .+ 1
         pix_periods = abs.(2π ./ (cdelt(wcs_m) .* angle_unit))
         rewind!(view(pixcoords, 1, :); period=pix_periods[1], ref_angle=center_pix[1])
         rewind!(view(pixcoords, 2, :); period=pix_periods[2], ref_angle=center_pix[2])
@@ -151,7 +151,7 @@ function sky2pix!(m::Enmap{T}, skycoords, pixcoords; safe=true) where T
     inverse_angle_unit = 1 / angle_unit
     world_to_pix!(getwcs(m), skycoords .* inverse_angle_unit, pixcoords)
     if safe
-        center_pix = size(m)[1:2] ./ 2
+        center_pix = size(m)[1:2] ./ 2 .+ 1
         pix_periods = abs.(2π ./ (cdelt(wcs_m) .* angle_unit))
         rewind!(view(pixcoords, 1, :); period=pix_periods[1], ref_angle=center_pix[1])
         rewind!(view(pixcoords, 2, :); period=pix_periods[2], ref_angle=center_pix[2])
@@ -336,7 +336,7 @@ function sky2pix!(m::Enmap{T,N,AA,CarClenshawCurtis}, skycoords::AbstractArray{T
     end
 
     if safe
-        center_pix = size(m)[1:2] ./ 2
+        center_pix = size(m)[1:2] ./ 2 .+ 1
         pix_periods = abs.(2π ./ (Δα, Δδ))
         rewind!(view(pixcoords, 1, :); period=pix_periods[1], ref_angle=center_pix[1])
         rewind!(view(pixcoords, 2, :); period=pix_periods[2], ref_angle=center_pix[2])
@@ -382,7 +382,7 @@ function sky2pix(m::Enmap{T,N,AA,CarClenshawCurtis},
     pix_dec = iδ₀ + (dec - δ₀) / Δδ
 
     if safe
-        center_pix = size(m)[1:2] ./ 2
+        center_pix = size(m)[1:2] ./ 2 .+ 1
         pix_ra = rewind(pix_ra; period=abs(2π / Δα), ref_angle=center_pix[1])
         pix_dec = rewind(pix_dec; period=abs(2π / Δδ), ref_angle=center_pix[2])
     end
@@ -400,7 +400,7 @@ function sky2pix(m::Enmap{T,N,AA,CarClenshawCurtis},
     pix_dec = iδ₀ .+ (dec .- δ₀) .* Δδ⁻¹
     
     if safe
-        center_pix = size(m)[1:2] ./ 2
+        center_pix = size(m)[1:2] ./ 2 .+ 1
         rewind!(pix_ra; period=abs(2π * Δα⁻¹), ref_angle=center_pix[1])
         rewind!(pix_dec; period=abs(2π * Δδ⁻¹), ref_angle=center_pix[2])
     end

--- a/src/enmap_ops.jl
+++ b/src/enmap_ops.jl
@@ -383,13 +383,13 @@ function sky2pix(m::Enmap{T,N,AA,CarClenshawCurtis},
 
     if safe
         center_pix = size(m)[1:2] ./ 2
-        pix_ra = rewind(pix_ra; period=2π / Δα, ref_angle=center_pix[1])
-        pix_dec = rewind(pix_dec; period=2π / Δδ, ref_angle=center_pix[2])
+        pix_ra = rewind(pix_ra; period=abs(2π / Δα), ref_angle=center_pix[1])
+        pix_dec = rewind(pix_dec; period=abs(2π / Δδ), ref_angle=center_pix[2])
     end
     return pix_ra, pix_dec
 end
 function sky2pix(m::Enmap{T,N,AA,CarClenshawCurtis}, 
-                 ra::AV, dec::AV) where {T,N,AA<:AbstractArray{T,N}, AV<:AbstractVector}
+                 ra::AV, dec::AV; safe=true) where {T,N,AA<:AbstractArray{T,N}, AV<:AbstractVector}
     wcs_m = getwcs(m)
     angle_unit = get_unit(T, wcs_m)
     α₀, δ₀ = crval(wcs_m) .* angle_unit
@@ -401,8 +401,8 @@ function sky2pix(m::Enmap{T,N,AA,CarClenshawCurtis},
     
     if safe
         center_pix = size(m)[1:2] ./ 2
-        rewind!(pix_ra; period=(2π * Δα⁻¹), ref_angle=center_pix[1])
-        rewind!(pix_dec; period=(2π * Δδ⁻¹), ref_angle=center_pix[2])
+        rewind!(pix_ra; period=abs(2π * Δα⁻¹), ref_angle=center_pix[1])
+        rewind!(pix_dec; period=abs(2π * Δδ⁻¹), ref_angle=center_pix[2])
     end
 
     return pix_ra, pix_dec

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,17 +76,17 @@ wrap(ra_dec_vec) = [mod(ra_dec_vec[1], 2π), mod(ra_dec_vec[2], π)]
 
     # check that our custom implementations 
     pixcoords = π .* rand(2, 1024)
-    skycoords = pix2sky(m, pixcoords)
+    skycoords = pix2sky(m, pixcoords; safe=false)
     @test skycoords ≈ Pixell.WCS.pix_to_world(Pixell.getwcs(m), pixcoords) .* (π/180)
     skycoords .= 0.0
-    pix2sky!(m, pixcoords, skycoords)
+    pix2sky!(m, pixcoords, skycoords; safe=false)
     @test skycoords ≈ Pixell.WCS.pix_to_world(Pixell.getwcs(m), pixcoords) .* (π/180)
     
     skycoords = π .* rand(2, 1024)
-    pixcoords = sky2pix(m, skycoords)
+    pixcoords = sky2pix(m, skycoords; safe=false)
     @test pixcoords ≈ Pixell.WCS.world_to_pix(Pixell.getwcs(m), skycoords .* (180/π))
     pixcoords .= 0.0
-    sky2pix!(m, skycoords, pixcoords)
+    sky2pix!(m, skycoords, pixcoords; safe=false)
     @test pixcoords ≈ Pixell.WCS.world_to_pix(Pixell.getwcs(m), skycoords .* (180/π))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,7 +74,11 @@ wrap(ra_dec_vec) = [mod(ra_dec_vec[1], 2π), mod(ra_dec_vec[2], π)]
     @test [1.0, 0.0] ≈ collect(sky2pix(m, pix2sky(m, [1.0, 0.0])))
     @test [13., 7.] ≈ collect(sky2pix(m, pix2sky(m, [13., 7.])))
 
-    # check that our custom implementations 
+    
+    @test [1.0, 0.0] ≈ collect(sky2pix(m, pix2sky(m, [1.0, 0.0]) .+ (2π, 6π)))
+    @test [13., 7.] ≈ collect(sky2pix(m, pix2sky(m, [13., 7.]) .+ (12π, 16π)))
+
+    # check our custom implementations
     pixcoords = π .* rand(2, 1024)
     skycoords = pix2sky(m, pixcoords; safe=false)
     @test skycoords ≈ Pixell.WCS.pix_to_world(Pixell.getwcs(m), pixcoords) .* (π/180)


### PR DESCRIPTION
This pr implements the "safe" wrapping behavior that is the default for sky2pix and pix2sky in python pixell. It's missing some tests still.

Thanks to @amaurea for explaining to me what the option does.