### PR TITLE
skyarea(shape, wcs)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,13 +14,14 @@ Healpix = "9f4e344d-96bc-545a-84a3-ae6b9e1b672b"
 Libsharp = "ac8d63fe-4615-43ae-9860-9cd4a3820532"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAngles = "6fb2a4bd-7999-5318-a3b2-8ad61056cd98"
 WCS = "15f3aee2-9e10-537f-b834-a6fb8bdb944d"
 
 [compat]
-Colors = "0.11, 0.12"
 ColorSchemes = "3"
+Colors = "0.11, 0.12"
 DSP = "0.7"
 FFTW = "1"
 FITSIO = "0.16"
@@ -28,6 +29,7 @@ FastTransforms = "0.13"
 Healpix = "3"
 Libsharp = "0.2"
 RecipesBase = "1"
+StaticArrays = "1"
 Unitful = "1"
 UnitfulAngles = "0.5, 0.6"
 WCS = "0.6.1"
@@ -35,8 +37,8 @@ julia = "1.6"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "DelimitedFiles", "Plots"]

--- a/src/Pixell.jl
+++ b/src/Pixell.jl
@@ -7,6 +7,7 @@ using FFTW
 using Printf
 import Unitful, UnitfulAngles
 import Unitful: uconvert, ustrip
+using StaticArrays
 using DSP: unwrap, unwrap!
 import FastTransforms: chebyshevjacobimoments1, clenshawcurtisweights
 using Libsharp
@@ -20,7 +21,7 @@ include("transforms.jl")
 
 export Enmap, CarClenshawCurtis, getwcs
 export geometry, fullsky_geometry, slice_geometry
-export pix2sky, pix2sky!, sky2pix, sky2pix!
+export pix2sky, pix2sky!, sky2pix, sky2pix!, skyarea
 export read_map, write_map
 export Alm, map2alm
 

--- a/src/enmap_geom.jl
+++ b/src/enmap_geom.jl
@@ -1,14 +1,4 @@
 
-
-# abstract type AbstractMapProjection end
-# abstract type EquiCylProjection <: AbstractMapProjection end  # equidistant cylindrical projection
-# abstract type CarProjection <: EquiCylProjection end          # plate carrée
-
-# struct CarClenshawCurtis{W} <: CarProjection end      # plate carrée with pixels on poles and equator
-# CarClenshawCurtis() = CarClenshawCurtis{CarClenshawCurtis}
-# CarClenshawCurtis(::Type{W}) where {W <: AbstractWCSTransform} = CarClenshawCurtis{W}
-
-
 function create_car_wcs(::Type{WCSTransform}, cdelt, crpix, crval)
     wcs = WCSTransform(2;
         ctype = ["RA---CAR", "DEC--CAR"],

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -3,85 +3,89 @@ using Test
 import Pixell: degree, arcminute
 
 @testset "Enmap geometry" begin
-    shape, wcs = fullsky_geometry(deg2rad(1 / 60))
-    @test collect(wcs.cdelt) ≈ [-0.016666666666666666, 0.016666666666666666]
-    @test collect(wcs.crpix) ≈ [10800.5, 5401.0]
-    @test collect(wcs.crval) ≈ [0.008333333333333333, 0.0]
+    for W in (Pixell.WCS.WCSTransform, CarClenshawCurtis{Float64})
+        shape, wcs = fullsky_geometry(W, deg2rad(1 / 60))
+        @test collect(wcs.cdelt) ≈ [-0.016666666666666666, 0.016666666666666666]
+        @test collect(wcs.crpix) ≈ [10800.5, 5401.0]
+        @test collect(wcs.crval) ≈ [0.008333333333333333, 0.0]
 
-    shape, wcs = fullsky_geometry(deg2rad(1 / 61))
-    @test collect(wcs.cdelt) ≈ [-0.01639344262295082, 0.01639344262295082]
-    @test collect(wcs.crpix) ≈ [10980.5, 5491.0]
-    @test collect(wcs.crval) ≈ [0.00819672131147541, 0.0]
+        shape, wcs = fullsky_geometry(W, deg2rad(1 / 61))
+        @test collect(wcs.cdelt) ≈ [-0.01639344262295082, 0.01639344262295082]
+        @test collect(wcs.crpix) ≈ [10980.5, 5491.0]
+        @test collect(wcs.crval) ≈ [0.00819672131147541, 0.0]
 
-    shape, wcs = fullsky_geometry(deg2rad(5); dims=(3,))
-    @test shape == (72, 37, 3)
+        shape, wcs = fullsky_geometry(W, deg2rad(5); dims=(3,))
+        @test shape == (72, 37, 3)
 
-    box = [10  -10;           # RA
-           -5    5] * degree  # DEC
-    shape, wcs = geometry(CarClenshawCurtis, box, 0.5 * arcminute)
-    @test shape == (2400, 1200)
-    @test collect(wcs.cdelt) ≈ [-0.008333333333333333,  0.008333333333333333]
-    @test collect(wcs.crpix) == [1201, 601]
-    @test collect(wcs.crval) == [0.0, 0.0]
+        box = [10  -10;           # RA
+            -5    5] * degree  # DEC
+        shape, wcs = geometry(W, box, 0.5 * arcminute)
+        @test shape == (2400, 1200)
+        @test collect(wcs.cdelt) ≈ [-0.008333333333333333,  0.008333333333333333]
+        @test collect(wcs.crpix) == [1201, 601]
+        @test collect(wcs.crval) == [0.0, 0.0]
 
-    box = [11  -10;           # RA
-           -6    5] * degree  # DEC
-    shape, wcs = geometry(CarClenshawCurtis, box, 0.5 * arcminute)
-    @test shape == (2520, 1320)
-    @test collect(wcs.cdelt) ≈ [-0.008333333333333333,  0.008333333333333333]
-    @test collect(wcs.crpix) ≈ [1261, 721]
-    @test collect(wcs.crval) ≈ [0.5, 0.0]
+        box = [11  -10;           # RA
+            -6    5] * degree  # DEC
+        shape, wcs = geometry(W, box, 0.5 * arcminute)
+        @test shape == (2520, 1320)
+        @test collect(wcs.cdelt) ≈ [-0.008333333333333333,  0.008333333333333333]
+        @test collect(wcs.crpix) ≈ [1261, 721]
+        @test collect(wcs.crval) ≈ [0.5, 0.0]
 
-    box = [10   -4;           # RA
-           -3    5] * degree  # DEC
-    shape, wcs = geometry(CarClenshawCurtis, box, 0.5 * arcminute)
-    @test shape == (1680, 960)
-    @test collect(wcs.crpix) ≈ [841, 361]
-    @test collect(wcs.crval) ≈ [3.0, 0.0]
+        box = [10   -4;           # RA
+            -3    5] * degree  # DEC
+        shape, wcs = geometry(W, box, 0.5 * arcminute)
+        @test shape == (1680, 960)
+        @test collect(wcs.crpix) ≈ [841, 361]
+        @test collect(wcs.crval) ≈ [3.0, 0.0]
+    end
 end
 
 ##
 wrap(ra_dec_vec) = [mod(ra_dec_vec[1], 2π), mod(ra_dec_vec[2], π)]
 @testset "Enmap sky2pix and pix2sky" begin
-    shape, wcs = fullsky_geometry(deg2rad(1))
-    m = Enmap(rand(shape...), wcs)
-    # in this test, wrap to angles in [0, 2π] and [0, π] for RA and DEC
-    @test [3.12413936, -1.55334303] ≈ collect(pix2sky(m, [2.0, 2.0]))
-    @test [2.96705973, -1.79768913] ≈ collect(pix2sky(m, [11.0, -12.0]))
-    @test [2.44346095, -2.0943951] ≈ collect(pix2sky(m, [41.0, -29.0]))
-    @test [1.0, 0.0] ≈ collect(sky2pix(m, pix2sky(m, [1.0, 0.0])))
-    @test [13., 7.] ≈ collect(sky2pix(m, pix2sky(m, [13., 7.])))
-    
-    # test passing a vector
-    @test [[1.0], [0.0]] ≈ collect(sky2pix(m, pix2sky(m, [1.0], [0.0])...))
-    @test [[13.], [7.]] ≈ collect(sky2pix(m, pix2sky(m, [13.], [7.])...))
-    
-    # try some crazy angles
-    @test [1.0, 0.0] ≈ collect(sky2pix(m, pix2sky(m, [1.0, 0.0]) .+ (2π, 6π)))
-    @test [13., 7.] ≈ collect(sky2pix(m, pix2sky(m, [13., 7.]) .+ (12π, 16π)))
+    for W in (Pixell.WCS.WCSTransform, CarClenshawCurtis{Float64})
+        shape, wcs = fullsky_geometry(W, deg2rad(1))
+        m = Enmap(rand(shape...), wcs)
+        # in this test, wrap to angles in [0, 2π] and [0, π] for RA and DEC
+        @test [3.12413936, -1.55334303] ≈ collect(pix2sky(m, [2.0, 2.0]))
+        @test [2.96705973, -1.79768913] ≈ collect(pix2sky(m, [11.0, -12.0]))
+        @test [2.44346095, -2.0943951] ≈ collect(pix2sky(m, [41.0, -29.0]))
+        @test [1.0, 0.0] ≈ collect(sky2pix(m, pix2sky(m, [1.0, 0.0])))
+        @test [13., 7.] ≈ collect(sky2pix(m, pix2sky(m, [13., 7.])))
+        
+        # test passing a vector
+        @test [[1.0], [0.0]] ≈ collect(sky2pix(m, pix2sky(m, [1.0], [0.0])...))
+        @test [[13.], [7.]] ≈ collect(sky2pix(m, pix2sky(m, [13.], [7.])...))
+        
+        # try some crazy angles
+        @test [1.0, 0.0] ≈ collect(sky2pix(m, pix2sky(m, [1.0, 0.0]) .+ (2π, 6π)))
+        @test [13., 7.] ≈ collect(sky2pix(m, pix2sky(m, [13., 7.]) .+ (12π, 16π)))
 
-    # check our custom implementations
-    pixcoords = π .* rand(2, 1024)
-    skycoords = pix2sky(m, pixcoords; safe=false)
-    shape, wcs_generic = fullsky_geometry(Pixell.WCS.WCSTransform, deg2rad(1))
-    @test skycoords ≈ Pixell.WCS.pix_to_world(wcs_generic, pixcoords) .* (π/180)
-    skycoords .= 0.0
-    pix2sky!(m, pixcoords, skycoords; safe=false)
-    @test skycoords ≈ Pixell.WCS.pix_to_world(wcs_generic, pixcoords) .* (π/180)
-    
-    skycoords = π .* rand(2, 1024)
-    pixcoords = sky2pix(m, skycoords; safe=false)
-    @test pixcoords ≈ Pixell.WCS.world_to_pix(wcs_generic, skycoords .* (180/π))
-    pixcoords .= 0.0
-    sky2pix!(m, skycoords, pixcoords; safe=false)
-    @test pixcoords ≈ Pixell.WCS.world_to_pix(wcs_generic, skycoords .* (180/π))
+        # check our custom implementations
+        pixcoords = π .* rand(2, 1024)
+        skycoords = pix2sky(m, pixcoords; safe=false)
+        shape, wcs_generic = fullsky_geometry(Pixell.WCS.WCSTransform, deg2rad(1))
+        @test skycoords ≈ Pixell.WCS.pix_to_world(wcs_generic, pixcoords) .* (π/180)
+        skycoords .= 0.0
+        pix2sky!(m, pixcoords, skycoords; safe=false)
+        @test skycoords ≈ Pixell.WCS.pix_to_world(wcs_generic, pixcoords) .* (π/180)
+        
+        skycoords = π .* rand(2, 1024)
+        pixcoords = sky2pix(m, skycoords; safe=false)
+        @test pixcoords ≈ Pixell.WCS.world_to_pix(wcs_generic, skycoords .* (180/π))
+        pixcoords .= 0.0
+        sky2pix!(m, skycoords, pixcoords; safe=false)
+        @test pixcoords ≈ Pixell.WCS.world_to_pix(wcs_generic, skycoords .* (180/π))
 
-    box = [10   -10;           # RA
-           -5     5] * degree  # DEC
-    shape, wcs = geometry(CarClenshawCurtis, box, 1 * degree)
-    m = Enmap(ones(shape), wcs)
-    @test [sky2pix(m, deg2rad(ra), 0.0; safe=true)[1]
-        for ra in 178:182] ≈ [-167., -168., -169.,  190.,  189.]
+        box = [10   -10;           # RA
+            -5     5] * degree  # DEC
+        shape, wcs = geometry(W, box, 1 * degree)
+        m = Enmap(ones(shape), wcs)
+        @test [sky2pix(m, deg2rad(ra), 0.0; safe=true)[1]
+            for ra in 178:182] ≈ [-167., -168., -169.,  190.,  189.]
+    end
 end
 
 ##
@@ -127,13 +131,14 @@ end
 ##
 @testset "sky2pix every single pixel" begin
     box = [10   -10;           # RA
-           -5     5] * degree  # DEC
+        -5     5] * degree  # DEC
     shape, wcs = geometry(CarClenshawCurtis, box, 1 * degree)
     m = Enmap(ones(shape), wcs)
     for i in 1:shape[1]
         for j in 1:shape[2]
             ra, dec = pix2sky(m, i, j)
             ra_unsafe, dec_unsafe = pix2sky(m, i, j; safe=false)
+            @show i, j
             @test ra ≈ ra_unsafe 
             @test dec ≈ dec_unsafe
             
@@ -230,5 +235,22 @@ end
         @test [-1.0, 3.0] ≈ collect(wcs.cdelt)
         @test [178.5, 30.666666666666668] ≈ collect(wcs.crpix)
         @test [0.5, 0.0] ≈ collect(wcs.crval)
+    end
+end
+
+## 
+@testset "pixel skyareas" begin
+    for W in (Pixell.WCS.WCSTransform, CarClenshawCurtis{Float64})
+        shape, wcs = fullsky_geometry(W, deg2rad(1))
+        @test skyarea(shape, wcs) ≈ 4π
+
+        shape′, wcs′ = slice_geometry(shape, wcs, 9:-1:3, 1:2)
+        @test skyarea(shape′, wcs′) ≈ 4.1865652086145036e-05
+
+        box = [10   -10;           # RA
+               -5     5] * degree  # DEC
+        shape, wcs = geometry(CarClenshawCurtis, box, (1/60) * degree)
+        @show shape wcs
+        @test skyarea(shape, wcs) ≈ 0.06084618627514243
     end
 end

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -138,7 +138,6 @@ end
         for j in 1:shape[2]
             ra, dec = pix2sky(m, i, j)
             ra_unsafe, dec_unsafe = pix2sky(m, i, j; safe=false)
-            @show i, j
             @test ra ≈ ra_unsafe 
             @test dec ≈ dec_unsafe
             
@@ -250,7 +249,6 @@ end
         box = [10   -10;           # RA
                -5     5] * degree  # DEC
         shape, wcs = geometry(CarClenshawCurtis, box, (1/60) * degree)
-        @show shape wcs
         @test skyarea(shape, wcs) ≈ 0.06084618627514243
     end
 end


### PR DESCRIPTION
This short PR adds a pretty useful function, `skyarea(shape, wcs)` that takes in geometry and returns the total sky area in steradians. This is useful for stuff like FFT normalization, for example.