### PR TITLE
trim WCS by default when reading from disk

### DIFF
--- a/test/test_enmap.jl
+++ b/test/test_enmap.jl
@@ -140,7 +140,7 @@ end
     @test stride(m,1) == 1
     @test stride(m,2) == stride(m.data, 2)
     
-    imap = read_map("data/test.fits")
+    imap = read_map("data/test.fits"; trim=false)
     @test Pixell.getunit(imap.wcs) ≈ π/180
     @test sprint(show, imap.wcs) == "WCSTransform(naxis=2,cdelt=[-1.0, 1.0],crval=[0.5, 0.0],crpix=[180.5, 91.0])"
 

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -1,14 +1,16 @@
 
 
 @testset "Enmap I/O" begin
-    imap = read_map("data/test.fits")
+    imap = read_map("data/test.fits"; trim=false)
     @test size(imap) == (100, 100, 3)
     @test imap.wcs.naxis == 2
     @test imap.wcs.cdelt == [-1, 1]
     @test imap.wcs.crval == [0.5, 0.0]
     @test sum(imap) ≈ 14967.2985
     # read with sel
-    imap = read_map("data/test.fits", sel=(11:20,21:40,1:2))
+    imap = read_map("data/test.fits", sel=(11:20,21:40,1:2); trim=false)
+    @test size(imap) == (10,20,2)
+    imap = read_map("data/test.fits", sel=(11:20,21:40,1:2); trim=true)
     @test size(imap) == (10,20,2)
     # todo: add tests on IAU conversion w/ and w/o sel
 end


### PR DESCRIPTION
This PR adds a kwarg to `read_map`, `trim=true`. If set to true, the generic WCS obtained from the FITS file will be converted to our fast version that only has cdelt, crpix, and crval. If set to false, the original behavior of using a generic C WCS structure will happen.