### PR TITLE
adjust lmax to not be crazy high

### DIFF
--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -76,7 +76,7 @@ function create_sht_band(m::Enmap)
 end
 
 """Generate an estimate of the Nyquist frequency for a map"""
-getlmax(wcs) = 3 * fullringsize(wcs)
+getlmax(wcs) = fullringsize(wcs) ÷ 2
 
 """perform forward SHT of an intensity map"""
 function map2alm(input_map::Enmap{T,2}; lmax=nothing, mmax=lmax) where T

--- a/test/test_transforms.jl
+++ b/test/test_transforms.jl
@@ -18,7 +18,7 @@ end
     ref_alms = data[:,1] + 1im .* data[:,2]
     @test (alms.alm ≈ ref_alms)
 
-    @test length(map2alm(m).alm) ==5995
+    @test length(map2alm(m).alm) == 190
     
     alms = map2alm(m[6:end-2, 5:end-3]; lmax=18)
     data = readdlm("data/simple_analytic_sht_sliced.txt")


### PR DESCRIPTION
The default lmax for map2alm was crazy high, no need for that.