### PR TITLE
fix bug in sub

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAngles = "6fb2a4bd-7999-5318-a3b2-8ad61056cd98"
 WCS = "15f3aee2-9e10-537f-b834-a6fb8bdb944d"
+WCS_jll = "550c8279-ae0e-5d1b-948f-937f2608a23e"
 
 [compat]
 ColorSchemes = "3"

--- a/src/Pixell.jl
+++ b/src/Pixell.jl
@@ -1,6 +1,7 @@
 module Pixell
 
 using WCS
+using WCS_jll
 import WCS: AbstractWCSTransform
 using FITSIO
 using FFTW


### PR DESCRIPTION
This PR addresses #42. I originally thought I can get away with simply changing axis, but this causes problem in field such as wcs.lin which stores a transformation matrix. A mismatch in naxis will result in overflow. Here I do it properly by using wcssub function in libwcs.