### PR TITLE
remove type ambiguity for view slices

### DIFF
--- a/src/enmap.jl
+++ b/src/enmap.jl
@@ -35,23 +35,21 @@ Base.size(x::Enmap) = size(parent(x))
 Base.axes(x::Enmap) = Base.axes(parent(x))
 Base.IndexStyle(x::Enmap) = IndexStyle(parent(x))
 
-@propagate_inbounds function Base.view(x::Enmap, idxs::ViewIndex...) 
-    new_shape, new_wcs = slice_geometry(x, idxs...)
-    Enmap(view(parent(x), idxs...), new_wcs)
-end
-@propagate_inbounds function Base.view(x::Enmap, idxs::Union{ViewIndex,AbstractCartesianIndex}...) 
-    new_shape, new_wcs = slice_geometry(x, idxs...)
-    Enmap(view(parent(x), idxs...), new_wcs)
-end
+const NotIntIndex = Union{AbstractArray,AbstractCartesianIndex,Colon}
+const AnyIndex = Union{ViewIndex,AbstractCartesianIndex,Colon}
 @propagate_inbounds function Base.view(x::Enmap, idxs...) 
     new_shape, new_wcs = slice_geometry(x, idxs...)
     Enmap(view(parent(x), idxs...), new_wcs)
 end
 
-# totally give up if the RA and DEC slices are eliminated, and just return a view of the parent
-@propagate_inbounds Base.view(x::Enmap, ix::Integer, idxs...) = view(parent(x), ix, idxs...)
-@propagate_inbounds Base.view(x::Enmap, ix, iy::Integer, idxs...) = view(parent(x), ix, iy, idxs...)
 
+# totally give up if the RA and DEC slices are eliminated, and just return a view of the parent
+@propagate_inbounds Base.view(x::Enmap, ix::Int, iy::NotIntIndex, idxs::AnyIndex...) = 
+    view(parent(x), ix, iy, idxs...)
+@propagate_inbounds Base.view(x::Enmap, ix::NotIntIndex, iy::Int, idxs::AnyIndex...) = 
+    view(parent(x), ix, iy, idxs...)
+@propagate_inbounds Base.view(x::Enmap, ix::Int, iy::Int, idxs::AnyIndex...) = 
+    view(parent(x), ix, iy, idxs...)
 
 @propagate_inbounds Base.getindex(x::Enmap, i::Int...) = getindex(parent(x), i...)
 @propagate_inbounds function Base.getindex(x::Enmap, i...)

--- a/test/test_enmap.jl
+++ b/test/test_enmap.jl
@@ -177,3 +177,15 @@ end
     @test collect(wcs0.crpix) ≈ collect(wcs.crpix)
     @test collect(wcs0.crval) ≈ collect(wcs.crval)
 end
+
+@testset "collapse to parent array for enmap view when slicing ra or dec" begin
+    shape0, wcs0 = fullsky_geometry(π/180)
+    m = Enmap(rand(shape0...), wcs0)
+    m[1,5:10] .= 1
+
+    shape0, wcs0 = fullsky_geometry(π/180)
+    m = Enmap(rand(shape0...,2), wcs0)
+    mv = @view m[1,:,1]
+    @test typeof(mv) == SubArray{Float64, 1, Array{Float64, 3}, 
+        Tuple{Int64, Base.Slice{Base.OneTo{Int64}}, Int64}, true}
+end


### PR DESCRIPTION
This PR fixes a small bug which caused it to be ambiguous when one slices an Enmap in the first or second dimension. Default behavior for Pixell is to then return a view that views the parent, since the RA or DEC has been removed.